### PR TITLE
Adapt Vault Secret parsing to new Vault version

### DIFF
--- a/current.go
+++ b/current.go
@@ -38,14 +38,6 @@ func (r *VaultRole) Exists(config ExistsConfig) (bool, error) {
 	return false, nil
 }
 
-type role struct {
-	AllowBareDomains bool   `json:"allow_bare_domains"`
-	AllowSubdomains  bool   `json:"allow_subdomains"`
-	AllowedDomains   string `json:"allowed_domains"`
-	Organizations    string `json:"organization"` // NOTE the singular form here.
-	TTL              string `json:"ttl"`
-}
-
 func (r *VaultRole) Search(config SearchConfig) (Role, error) {
 	// Check if a PKI for the given cluster ID exists.
 	secret, err := r.vaultClient.Logical().Read(key.ReadRolePath(config.ID, config.Organizations))

--- a/current_test.go
+++ b/current_test.go
@@ -1,0 +1,257 @@
+package vaultrole
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/microerror"
+	"github.com/hashicorp/vault/api"
+)
+
+func Test_vaultSecretToRole(t *testing.T) {
+	testCases := []struct {
+		name         string
+		input        *api.Secret
+		expectedRole Role
+		errorMatcher func(error) bool
+	}{
+		{
+			name: "case 0: test pre-vault-update with concatenated altnames in single string",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": true,
+					"allow_subdomains":   true,
+					"allowed_domains":    "foo.com,bar.com,baz.com",
+					"organization":       "Foobar",
+					"ttl":                "3600s",
+				},
+			},
+			expectedRole: Role{
+				AllowBareDomains: true,
+				AllowSubdomains:  true,
+				AltNames:         []string{"bar.com", "baz.com"},
+				Organizations:    []string{"Foobar"},
+				TTL:              3600 * time.Second,
+			},
+			errorMatcher: nil,
+		},
+		{
+			name: "case 1: test post-vault-update with altnames as slice of interfaces which are string underneath",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": true,
+					"allow_subdomains":   true,
+					"allowed_domains":    []interface{}{"foo.com", "bar.com", "baz.com"},
+					"organization":       "Foobar",
+					"ttl":                "3600s",
+				},
+			},
+			expectedRole: Role{
+				AllowBareDomains: true,
+				AllowSubdomains:  true,
+				AltNames:         []string{"bar.com", "baz.com"},
+				Organizations:    []string{"Foobar"},
+				TTL:              3600 * time.Second,
+			},
+			errorMatcher: nil,
+		},
+		{
+			name: "case 2: test with altnames as slice of string",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": true,
+					"allow_subdomains":   true,
+					"allowed_domains":    []string{"foo.com", "bar.com", "baz.com"},
+					"organization":       "Foobar",
+					"ttl":                "3600s",
+				},
+			},
+			expectedRole: Role{
+				AllowBareDomains: true,
+				AllowSubdomains:  true,
+				AltNames:         []string{"bar.com", "baz.com"},
+				Organizations:    []string{"Foobar"},
+				TTL:              3600 * time.Second,
+			},
+			errorMatcher: nil,
+		},
+		{
+			name: "case 3: test missing allow_bare_domains field causes invalidConfigError",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_subdomains": true,
+					"allowed_domains":  []string{"foo.com", "bar.com", "baz.com"},
+					"organization":     "Foobar",
+					"ttl":              "3600s",
+				},
+			},
+			expectedRole: Role{},
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 4: test missing allow_subdomains field causes invalidConfigError",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": true,
+					"allowed_domains":    []string{"foo.com", "bar.com", "baz.com"},
+					"organization":       "Foobar",
+					"ttl":                "3600s",
+				},
+			},
+			expectedRole: Role{},
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 5: test missing allowed_domains field causes invalidConfigError",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": true,
+					"allow_subdomains":   true,
+					"organization":       "Foobar",
+					"ttl":                "3600s",
+				},
+			},
+			expectedRole: Role{},
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 6: test missing organization field causes invalidConfigError",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": true,
+					"allow_subdomains":   true,
+					"allowed_domains":    []string{"foo.com", "bar.com", "baz.com"},
+					"ttl":                "3600s",
+				},
+			},
+			expectedRole: Role{},
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 6: test missing ttl field causes invalidConfigError",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": true,
+					"allow_subdomains":   true,
+					"allowed_domains":    []string{"foo.com", "bar.com", "baz.com"},
+					"organization":       "Foobar",
+				},
+			},
+			expectedRole: Role{},
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 7: test wrong type in allow_bare_domains field causes wrongTypeError",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": int(42),
+					"allow_subdomains":   true,
+					"allowed_domains":    []string{"foo.com", "bar.com", "baz.com"},
+					"organization":       "Foobar",
+					"ttl":                "3600s",
+				},
+			},
+			expectedRole: Role{},
+			errorMatcher: IsWrongType,
+		},
+		{
+			name: "case 8: test wrong type in allow_subdomains field causes wrongTypeError",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": true,
+					"allow_subdomains":   string("foobar"),
+					"allowed_domains":    []string{"foo.com", "bar.com", "baz.com"},
+					"organization":       "Foobar",
+					"ttl":                "3600s",
+				},
+			},
+			expectedRole: Role{},
+			errorMatcher: IsWrongType,
+		},
+		{
+			name: "case 9: test wrong type in allowed_domains field causes wrongTypeError",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": true,
+					"allow_subdomains":   true,
+					"allowed_domains":    []int{1, 3, 5, 7, 11, 13},
+					"organization":       "Foobar",
+					"ttl":                "3600s",
+				},
+			},
+			expectedRole: Role{},
+			errorMatcher: IsWrongType,
+		},
+		{
+			name: "case 10: test wrong type in organization field causes wrongTypeError",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": true,
+					"allow_subdomains":   true,
+					"allowed_domains":    []string{"foo.com", "bar.com", "baz.com"},
+					"organization":       struct{}{},
+					"ttl":                "3600s",
+				},
+			},
+			expectedRole: Role{},
+			errorMatcher: IsWrongType,
+		},
+		{
+			name: "case 11: test wrong type in ttl field causes wrongTypeError",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": true,
+					"allow_subdomains":   true,
+					"allowed_domains":    []string{"foo.com", "bar.com", "baz.com"},
+					"organization":       "Foobar",
+					"ttl":                struct{}{},
+				},
+			},
+			expectedRole: Role{},
+			errorMatcher: IsWrongType,
+		},
+		{
+			name: "case 12: test invalid ttl field causes wrongTypeError",
+			input: &api.Secret{
+				Data: map[string]interface{}{
+					"allow_bare_domains": true,
+					"allow_subdomains":   true,
+					"allowed_domains":    []string{"foo.com", "bar.com", "baz.com"},
+					"organization":       "Foobar",
+					"ttl":                "unparseable",
+				},
+			},
+			expectedRole: Role{},
+			errorMatcher: func(e error) bool {
+				if _, ok := microerror.Cause(e).(*strconv.NumError); ok {
+					return true
+				}
+				return false
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			role, err := vaultSecretToRole(tc.input)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(role, tc.expectedRole) {
+				t.Fatalf("Role == %#v, want %#v", role, tc.expectedRole)
+			}
+		})
+	}
+}

--- a/error.go
+++ b/error.go
@@ -39,3 +39,10 @@ func IsNoVaultHandlerDefined(err error) bool {
 
 	return false
 }
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}


### PR DESCRIPTION
New Vault version (0.9.3 for us) changed type of allowed_domains
property in api.Secret. Earlier it was string where values were
concatenated with comma, now it's []interface{} which actually hides
strings underneath.

To support old versions together with new version, specific parsing for
api.Secret -> Role was implemented.