### PR TITLE
Improve error naming for errors related to api.Secret.Data

### DIFF
--- a/current.go
+++ b/current.go
@@ -69,12 +69,12 @@ func vaultSecretToRole(secret *api.Secret) (Role, error) {
 	{
 		v, exists := secret.Data["allow_bare_domains"]
 		if !exists {
-			return Role{}, microerror.Maskf(invalidConfigError, "allow_bare_domains missing from Vault api.Secret.Data")
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "allow_bare_domains missing from Vault api.Secret.Data")
 		}
 
 		allowBareDomains, ok := v.(bool)
 		if !ok {
-			return Role{}, microerror.Maskf(wrongTypeError, "Vault secret.Data[\"allow_bare_domains\"] type is %T, expected %T", secret.Data["allow_bare_domains"], allowBareDomains)
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "Vault secret.Data[\"allow_bare_domains\"] type is %T, expected %T", secret.Data["allow_bare_domains"], allowBareDomains)
 		}
 
 		role.AllowBareDomains = allowBareDomains
@@ -83,12 +83,12 @@ func vaultSecretToRole(secret *api.Secret) (Role, error) {
 	{
 		v, exists := secret.Data["allow_subdomains"]
 		if !exists {
-			return Role{}, microerror.Maskf(invalidConfigError, "allow_subdomains missing from Vault api.Secret.Data")
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "allow_subdomains missing from Vault api.Secret.Data")
 		}
 
 		allowSubdomains, ok := v.(bool)
 		if !ok {
-			return Role{}, microerror.Maskf(wrongTypeError, "Vault secret.Data[\"allow_subdomains\"] type is %T, expected %T", secret.Data["allow_subdomains"], allowSubdomains)
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "Vault secret.Data[\"allow_subdomains\"] type is %T, expected %T", secret.Data["allow_subdomains"], allowSubdomains)
 		}
 
 		role.AllowSubdomains = allowSubdomains
@@ -97,7 +97,7 @@ func vaultSecretToRole(secret *api.Secret) (Role, error) {
 	{
 		allowedDomains, exists := secret.Data["allowed_domains"]
 		if !exists {
-			return Role{}, microerror.Maskf(invalidConfigError, "allowed_domains missing from Vault api.Secret.Data")
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "allowed_domains missing from Vault api.Secret.Data")
 		}
 
 		// Types in secret.Data["allowed_domains"] differ between versions of
@@ -114,26 +114,26 @@ func vaultSecretToRole(secret *api.Secret) (Role, error) {
 				if s, ok := val.(string); ok {
 					allowedDomains = append(allowedDomains, s)
 				} else {
-					return Role{}, microerror.Maskf(wrongTypeError, "Vault secret.Data[\"allowed_domains\"][%d] has unexpected type '%T'. It's not string nor []string.", i, val)
+					return Role{}, microerror.Maskf(invalidVaultResponseError, "Vault secret.Data[\"allowed_domains\"][%d] has unexpected type '%T'. It's not string nor []string.", i, val)
 				}
 			}
 
 			// TODO: Why first one is dropped (this was in key.ToAltNames()?
 			role.AltNames = allowedDomains[1:]
 		default:
-			return Role{}, microerror.Maskf(wrongTypeError, "Vault secret.Data[\"allowed_domains\"] type is '%T'. It's not string, []string nor []interface{} (masking strings).", secret.Data["allowed_domains"])
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "Vault secret.Data[\"allowed_domains\"] type is '%T'. It's not string, []string nor []interface{} (masking strings).", secret.Data["allowed_domains"])
 		}
 	}
 
 	{
 		v, exists := secret.Data["organization"]
 		if !exists {
-			return Role{}, microerror.Maskf(invalidConfigError, "organization missing from Vault api.Secret.Data")
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "organization missing from Vault api.Secret.Data")
 		}
 
 		organization, ok := v.(string)
 		if !ok {
-			return Role{}, microerror.Maskf(wrongTypeError, "Vault secret.Data[\"organization\"] type is %T, expected %T", secret.Data["organization"], organization)
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "Vault secret.Data[\"organization\"] type is %T, expected %T", secret.Data["organization"], organization)
 		}
 
 		role.Organizations = key.ToOrganizations(organization)
@@ -142,12 +142,12 @@ func vaultSecretToRole(secret *api.Secret) (Role, error) {
 	{
 		v, exists := secret.Data["ttl"]
 		if !exists {
-			return Role{}, microerror.Maskf(invalidConfigError, "ttl missing from Vault api.Secret.Data")
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "ttl missing from Vault api.Secret.Data")
 		}
 
 		ttlStr, ok := v.(string)
 		if !ok {
-			return Role{}, microerror.Maskf(wrongTypeError, "Vault secret.Data[\"ttl\"] type is %T, expected %T", secret.Data["ttl"], ttlStr)
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "Vault secret.Data[\"ttl\"] type is %T, expected %T", secret.Data["ttl"], ttlStr)
 		}
 
 		ttl, err := parseutil.ParseDurationSecond(ttlStr)

--- a/current_test.go
+++ b/current_test.go
@@ -88,7 +88,7 @@ func Test_vaultSecretToRole(t *testing.T) {
 				},
 			},
 			expectedRole: Role{},
-			errorMatcher: IsInvalidConfig,
+			errorMatcher: IsInvalidVaultResponse,
 		},
 		{
 			name: "case 4: test missing allow_subdomains field causes invalidConfigError",
@@ -101,7 +101,7 @@ func Test_vaultSecretToRole(t *testing.T) {
 				},
 			},
 			expectedRole: Role{},
-			errorMatcher: IsInvalidConfig,
+			errorMatcher: IsInvalidVaultResponse,
 		},
 		{
 			name: "case 5: test missing allowed_domains field causes invalidConfigError",
@@ -114,7 +114,7 @@ func Test_vaultSecretToRole(t *testing.T) {
 				},
 			},
 			expectedRole: Role{},
-			errorMatcher: IsInvalidConfig,
+			errorMatcher: IsInvalidVaultResponse,
 		},
 		{
 			name: "case 6: test missing organization field causes invalidConfigError",
@@ -127,7 +127,7 @@ func Test_vaultSecretToRole(t *testing.T) {
 				},
 			},
 			expectedRole: Role{},
-			errorMatcher: IsInvalidConfig,
+			errorMatcher: IsInvalidVaultResponse,
 		},
 		{
 			name: "case 6: test missing ttl field causes invalidConfigError",
@@ -140,10 +140,10 @@ func Test_vaultSecretToRole(t *testing.T) {
 				},
 			},
 			expectedRole: Role{},
-			errorMatcher: IsInvalidConfig,
+			errorMatcher: IsInvalidVaultResponse,
 		},
 		{
-			name: "case 7: test wrong type in allow_bare_domains field causes wrongTypeError",
+			name: "case 7: test wrong type in allow_bare_domains field causes invalidVaultResponseError",
 			input: &api.Secret{
 				Data: map[string]interface{}{
 					"allow_bare_domains": int(42),
@@ -154,10 +154,10 @@ func Test_vaultSecretToRole(t *testing.T) {
 				},
 			},
 			expectedRole: Role{},
-			errorMatcher: IsWrongType,
+			errorMatcher: IsInvalidVaultResponse,
 		},
 		{
-			name: "case 8: test wrong type in allow_subdomains field causes wrongTypeError",
+			name: "case 8: test wrong type in allow_subdomains field causes invalidVaultResponseError",
 			input: &api.Secret{
 				Data: map[string]interface{}{
 					"allow_bare_domains": true,
@@ -168,10 +168,10 @@ func Test_vaultSecretToRole(t *testing.T) {
 				},
 			},
 			expectedRole: Role{},
-			errorMatcher: IsWrongType,
+			errorMatcher: IsInvalidVaultResponse,
 		},
 		{
-			name: "case 9: test wrong type in allowed_domains field causes wrongTypeError",
+			name: "case 9: test wrong type in allowed_domains field causes invalidVaultResponseError",
 			input: &api.Secret{
 				Data: map[string]interface{}{
 					"allow_bare_domains": true,
@@ -182,10 +182,10 @@ func Test_vaultSecretToRole(t *testing.T) {
 				},
 			},
 			expectedRole: Role{},
-			errorMatcher: IsWrongType,
+			errorMatcher: IsInvalidVaultResponse,
 		},
 		{
-			name: "case 10: test wrong type in organization field causes wrongTypeError",
+			name: "case 10: test wrong type in organization field causes invalidVaultResponseError",
 			input: &api.Secret{
 				Data: map[string]interface{}{
 					"allow_bare_domains": true,
@@ -196,10 +196,10 @@ func Test_vaultSecretToRole(t *testing.T) {
 				},
 			},
 			expectedRole: Role{},
-			errorMatcher: IsWrongType,
+			errorMatcher: IsInvalidVaultResponse,
 		},
 		{
-			name: "case 11: test wrong type in ttl field causes wrongTypeError",
+			name: "case 11: test wrong type in ttl field causes invalidVaultResponseError",
 			input: &api.Secret{
 				Data: map[string]interface{}{
 					"allow_bare_domains": true,
@@ -210,10 +210,10 @@ func Test_vaultSecretToRole(t *testing.T) {
 				},
 			},
 			expectedRole: Role{},
-			errorMatcher: IsWrongType,
+			errorMatcher: IsInvalidVaultResponse,
 		},
 		{
-			name: "case 12: test invalid ttl field causes wrongTypeError",
+			name: "case 12: test invalid ttl field causes invalidVaultResponseError",
 			input: &api.Secret{
 				Data: map[string]interface{}{
 					"allow_bare_domains": true,

--- a/error.go
+++ b/error.go
@@ -20,6 +20,13 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
+var invalidVaultResponseError = microerror.New("invalid vault response")
+
+// IsInvalidVaultResponse asserts invalidVaultResponseError
+func IsInvalidVaultResponse(err error) bool {
+	return microerror.Cause(err) == invalidVaultResponseError
+}
+
 var notFoundError = microerror.New("not found")
 
 // IsNotFound asserts notFoundError.
@@ -38,11 +45,4 @@ func IsNoVaultHandlerDefined(err error) bool {
 	}
 
 	return false
-}
-
-var wrongTypeError = microerror.New("wrong type")
-
-// IsWrongType asserts wrongTypeError.
-func IsWrongType(err error) bool {
-	return microerror.Cause(err) == wrongTypeError
 }


### PR DESCRIPTION
invalidConfigError is meant to be used for program initiation
configuration errors and wrongTypeError can also be improved by using
invalidVaultResponseError for both of these cases when parsing Vault API
response.